### PR TITLE
Update Transaction.cs

### DIFF
--- a/Recurly/Resources/Transaction.cs
+++ b/Recurly/Resources/Transaction.cs
@@ -96,7 +96,7 @@ namespace Recurly.Resources
 
         /// <value>The values in this field will vary from gateway to gateway.</value>
         [JsonProperty("gateway_response_values")]
-        public Dictionary<string, string> GatewayResponseValues { get; set; }
+        public Dictionary<string, object> GatewayResponseValues { get; set; }
 
         /// <value>Transaction ID</value>
         [JsonProperty("id")]


### PR DESCRIPTION
To be more consistent with API Transaction gateway_responce_values declaration this should be object.  Updated Dictionary<string, string> on Dictionary<string, object> to avoid deserialization exception.